### PR TITLE
Add support for disabling converting placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,11 @@ lokalise {
         defaultLang = "en"  // default language which will be put into values/strings.xml
     }  
   
-    //Here you can specify which files you want to upload
+    //Here you can specify which files you want to upload. convertPlaceholders is true by default
     uploadEntry {  
         path = "$rootDir/app/src/main/res/values/strings.xml"  
-        lang = "en"  
+        lang = "en"
+        convertPlaceholders = false
     }  
     uploadEntry {  
         path = "$rootDir/app/src/main/res/values-pt/strings.xml"  

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.4.10'
+    ext.kotlin_version = '1.7.10'
 
     repositories {
         mavenCentral()

--- a/src/main/kotlin/org/rnazarevych/lokalise/DocumentEx.kt
+++ b/src/main/kotlin/org/rnazarevych/lokalise/DocumentEx.kt
@@ -12,10 +12,10 @@ const val EMPTY_NODE_EXPRESSION = "//text()[normalize-space(.)='']"
 fun Document.removeEmptyNodes() {
     val xp: XPath = XPathFactory.newInstance().newXPath()
     val nodes: NodeList = xp.evaluate(EMPTY_NODE_EXPRESSION, this, XPathConstants.NODESET) as NodeList
-    for (i in 0 until nodes.getLength()) {
+    for (i in 0 until nodes.length) {
         val node: Node = nodes.item(i)
         if (node.textContent.trim().isEmpty()) {
-            node.getParentNode().removeChild(node)
+            node.parentNode.removeChild(node)
         }
     }
 }

--- a/src/main/kotlin/org/rnazarevych/lokalise/LokalisePlugin.kt
+++ b/src/main/kotlin/org/rnazarevych/lokalise/LokalisePlugin.kt
@@ -80,5 +80,6 @@ open class StringsUploadConfig {
 
 open class UploadEntry(
     var path: String = "",
-    var lang: String = ""
+    var lang: String = "",
+    var convertPlaceholders: Boolean = true
 )

--- a/src/main/kotlin/org/rnazarevych/lokalise/api/dto/Dto.kt
+++ b/src/main/kotlin/org/rnazarevych/lokalise/api/dto/Dto.kt
@@ -2,6 +2,9 @@ package org.rnazarevych.lokalise.api.dto
 
 import com.google.gson.annotations.SerializedName
 
+/**
+ * https://developers.lokalise.com/reference/upload-a-file
+ */
 data class UploadFileDto(
         /**
          * Base64 encoded file. Must be one of the supported file types.
@@ -9,6 +12,11 @@ data class UploadFileDto(
         val data: String,
         val filename: String,
         @SerializedName("lang_iso")
-        val langIso: String
+        val langIso: String,
+        /**
+         * Enable to automatically convert placeholders to the Lokalise universal placeholders.
+         */
+        @SerializedName("convert_placeholders")
+        val convertPlaceholders: Boolean
 )
 

--- a/src/main/kotlin/org/rnazarevych/lokalise/tasks/UploadStrings.kt
+++ b/src/main/kotlin/org/rnazarevych/lokalise/tasks/UploadStrings.kt
@@ -44,7 +44,8 @@ open class UploadStrings : DefaultTask() {
             val dto = UploadFileDto(
                 data,
                 file.name,
-                entry.lang
+                entry.lang,
+                entry.convertPlaceholders
             )
 
             val response = Api.api.uploadFile(apiConfig.projectId,dto).execute()


### PR DESCRIPTION
Lokalise automatically converts placeholders to its own format.
This adds ability to disable it.