### PR TITLE
Change translationId from Int to Long

### DIFF
--- a/src/main/kotlin/org/rnazarevych/lokalise/api/dto/TranslationsResponse.kt
+++ b/src/main/kotlin/org/rnazarevych/lokalise/api/dto/TranslationsResponse.kt
@@ -59,7 +59,7 @@ data class Translation(
     @SerializedName("translation")
     val translation: String,
     @SerializedName("translation_id")
-    val translationId: Int,
+    val translationId: Long,
     @SerializedName("words")
     val words: Int
 )


### PR DESCRIPTION
To avoid java.lang.NumberFormatException: Expected an int but was 2377419655