### PR TITLE
Update Gradle to 9.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,7 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 buildscript {
-    ext.kotlin_version = '1.9.20'
+    ext.kotlin_version = '2.2.0'
 
     repositories {
         mavenCentral()
@@ -50,16 +52,16 @@ dependencies {
     implementation 'com.squareup.okhttp3:logging-interceptor:3.11.0'
 
 
-    testImplementation group: 'junit', name: 'junit', version: '4.12'
+    testImplementation 'junit:junit:4.12'
 }
 
-compileKotlin {
-    kotlinOptions.jvmTarget = "17"
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+kotlin {
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_17
+    }
 }
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "17"
+
+java {
     sourceCompatibility = JavaVersion.VERSION_17
     targetCompatibility = JavaVersion.VERSION_17
 }

--- a/build.gradle
+++ b/build.gradle
@@ -47,9 +47,9 @@ dependencies {
     implementation 'commons-codec:commons-codec:1.14'
 
     //Network
-    implementation 'com.squareup.retrofit2:retrofit:2.5.0'
-    implementation 'com.squareup.retrofit2:converter-gson:2.5.0'
-    implementation 'com.squareup.okhttp3:logging-interceptor:3.11.0'
+    implementation 'com.squareup.retrofit2:retrofit:3.0.0'
+    implementation 'com.squareup.retrofit2:converter-gson:3.0.0'
+    implementation 'com.squareup.okhttp3:logging-interceptor:5.3.2'
 
 
     testImplementation 'junit:junit:4.12'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 kotlin.code.style=official
+org.gradle.configuration-cache=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/com/oitchau/lokalise/LokalisePlugin.kt
+++ b/src/main/kotlin/com/oitchau/lokalise/LokalisePlugin.kt
@@ -22,12 +22,12 @@ class LokalisePlugin : Plugin<Project> {
         project.afterEvaluate {
 
             project.tasks.apply {
-                create("uploadStrings", UploadStrings::class.java) {
+                register("uploadStrings", UploadStrings::class.java) {
                     it.apiConfig = config.api
 //                    it.uploadEntries = config.stringsUploadConfig.uploadEntries
                     it.uploadEntries = config.uploadEntries
                 }
-                create("downloadTranslations", DownloadProjectData::class.java) {
+                register("downloadTranslations", DownloadProjectData::class.java) {
                     it.apiConfig = config.api
                     it.config = config.translationsUpdateConfig
                 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Build tooling upgrades (Gradle/Kotlin/Retrofit/OkHttp) can introduce compilation or runtime incompatibilities, and task registration changes may affect task configuration timing.
> 
> **Overview**
> Upgrades build tooling to newer versions: Kotlin `1.9.20` 	`2.2.0`, Gradle wrapper to `9.1.0`, and enables Gradle configuration cache.
> 
> Updates network dependencies to Retrofit `3.0.0` and OkHttp logging interceptor `5.3.2`, modernizes Kotlin/JVM configuration via `kotlin { compilerOptions { jvmTarget = JVM_17 } }`, and switches plugin task creation from `create` to lazy `register` for `uploadStrings` and `downloadTranslations`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f075ec17b6554501203c69e95b8c477ad32de17f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->