### PR TITLE
Fix configuration cache crash

### DIFF
--- a/src/main/kotlin/com/oitchau/lokalise/tasks/TranslationWriter.kt
+++ b/src/main/kotlin/com/oitchau/lokalise/tasks/TranslationWriter.kt
@@ -14,7 +14,11 @@ import javax.xml.transform.stream.StreamResult
 
 internal class TranslationWriter {
 
-    private val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+    companion object {
+        private const val PATTERN = "yyyy-MM-dd HH:mm:ss"
+    }
+
+    private fun formatter(): DateTimeFormatter = DateTimeFormatter.ofPattern(PATTERN)
 
     fun update(translationKeys: TranslationsResponse, lang: String, file: File) {
         println("Opening File ${file.absolutePath}")
@@ -49,16 +53,16 @@ internal class TranslationWriter {
             val translation = translationKey?.translations?.find { it.languageIso == lang }
             if (translation != null) {
                 val localLmd = try {
-                    LocalDateTime.parse(string.getAttribute("lmt"), formatter)
+                    LocalDateTime.parse(string.getAttribute("lmt"), formatter())
                 } catch (ignored: Exception) {
                     LocalDateTime.of(1970, 1, 1, 1, 1, 1)
                 }
-                val remoteLmd = LocalDateTime.parse(trimTimeZone(translation.modifiedAt), formatter)
+                val remoteLmd = LocalDateTime.parse(trimTimeZone(translation.modifiedAt), formatter())
 
                 // if there is newer text on the backend
                 if (remoteLmd.isAfter(localLmd)) {
                     string.textContent = escapeXml(translation.translation)
-                    string.setAttribute("lmd", remoteLmd.format(formatter))
+                    string.setAttribute("lmd", remoteLmd.format(formatter()))
                     updatedCount++
 //                    println("$id -> ${entry.translation}")
                 }


### PR DESCRIPTION
Moving from field to fun lets gradle to not store DateTimeFormatter into configuration cache

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor limited to `TranslationWriter` date parsing/formatting; low behavioral risk aside from potential subtle differences in `DateTimeFormatter` instantiation timing.
> 
> **Overview**
> Refactors `TranslationWriter` to avoid keeping a `DateTimeFormatter` as a field by moving the pattern to a constant and creating the formatter via a helper function.
> 
> All timestamp parsing/formatting calls in `update()` are updated to use the new formatter factory, reducing the chance of Gradle configuration-cache serialization issues.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7045b062f459643b219ae97ef571085705700d8e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->